### PR TITLE
Change 'influxdb' dependency from development to runtime

### DIFF
--- a/fastlane-plugin-influxdb.gemspec
+++ b/fastlane-plugin-influxdb.gemspec
@@ -17,14 +17,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  # Don't add a dependency to fastlane or fastlane_re
+  # Don't add a dependency to fastlane
   # since this would cause a circular dependency
 
-  # spec.add_dependency 'your-dependency', '~> 1.0.0'
+  spec.add_dependency 'influxdb'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'fastlane', '>= 2.12.0'
-  spec.add_development_dependency 'influxdb'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'

--- a/lib/fastlane/plugin/influxdb/version.rb
+++ b/lib/fastlane/plugin/influxdb/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Influxdb
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
Closes #6 

I came to realise that if we don't list `influxdb` in our Gemspec then Fastlane will error with the following:

> Error loading plugin 'fastlane-plugin-influxdb': cannot load such file -- influxdb

Looking at the gemspec in this repo, I think that maybe `influxdb` needs to be listed as a regular dependency and not a development one? Is that correct @giginet? 